### PR TITLE
Organize input and error files by request

### DIFF
--- a/Managers/SapfirManager.cs
+++ b/Managers/SapfirManager.cs
@@ -167,20 +167,25 @@ namespace SpravkoBot_AsSapfir
         {
             if (session == null)
             {
-                throw new ArgumentNullException(nameof(session), "Сессия не может быть null.");
+                Log.Warn("CloseSAPWindowByNex вызван без активной сессии.");
+                return;
             }
 
             try
             {
-                var mainWindow = session.FindById("wnd[0]") as GuiMainWindow ??
-                                 throw new InvalidOperationException("Главное окно 'wnd[0]' не найдено.");
+                var mainWindow = session.FindById("wnd[0]") as GuiMainWindow;
+                if (mainWindow == null)
+                {
+                    Log.Warn("Главное окно 'wnd[0]' не найдено при попытке закрытия.");
+                    return;
+                }
 
                 // Выполняем команду /nex напрямую через HardCopy
                 session.SendCommand("/nex");
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException($"Ошибка при закрытии окна SAP: {ex.Message}", ex);
+                Log.Error(ex, $"Ошибка при закрытии окна SAP: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
## Summary
- Move each incoming request file into its own folder before processing
- Save SAP-generated error spreadsheets into the dedicated `error` directory
- Return moved file paths from the helper to support new workflow
- Avoid null-session crashes when attempting to close SAP

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c17792f4bc8323837ed9f5e18804b8